### PR TITLE
Update drupal.make

### DIFF
--- a/drupal.make
+++ b/drupal.make
@@ -3,4 +3,4 @@ core = 7.x
 
 ; Drupal core.
 projects[drupal][type] = core
-projects[drupal][version] = 7.35
+projects[drupal][version] = 7.38


### PR DESCRIPTION
Is there a reason to not use the latest Drupal core version? Updated to 7.38.
